### PR TITLE
sqlite3を1.4.1から1.4.2に更新

### DIFF
--- a/6_1/ch14/Gemfile
+++ b/6_1/ch14/Gemfile
@@ -19,7 +19,7 @@ gem 'jbuilder',   '2.9.1'
 gem 'bootsnap',   '1.4.5', require: false
 
 group :development, :test do
-  gem 'sqlite3', '1.4.1'
+  gem 'sqlite3', '1.4.2'
   gem 'byebug',  '11.0.1', platforms: [:mri, :mingw, :x64_mingw]
 end
 

--- a/6_1/ch14/Gemfile.lock
+++ b/6_1/ch14/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     msgpack (1.4.2)
     nenv (0.3.0)
     nio4r (2.5.8)
+    nokogiri (1.12.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -247,7 +249,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.4.2)
     thor (1.1.0)
     tilt (2.0.10)
     turbolinks (5.2.0)
@@ -277,6 +279,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-18
   x86_64-linux
 
@@ -306,7 +309,7 @@ DEPENDENCIES
   selenium-webdriver (= 3.142.4)
   spring (= 2.1.0)
   spring-watcher-listen (= 2.0.1)
-  sqlite3 (= 1.4.1)
+  sqlite3 (= 1.4.2)
   turbolinks (= 5.2.0)
   tzinfo-data
   web-console (= 4.0.1)


### PR DESCRIPTION
# 概要
M1 Mac環境での環境構築にて、sqlite3が 1.4.1 の場合は rails testコマンドにてエラーが出ていたので、1.4.2 にアップデートいたしました。
