### PR TITLE
Feature/notifications

### DIFF
--- a/6_1/ch14/app/assets/stylesheets/custom.scss
+++ b/6_1/ch14/app/assets/stylesheets/custom.scss
@@ -77,6 +77,23 @@ p {
   }
 }
 
+#notifications {
+  width: 300px;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.notification {
+  border: 1px solid $gray-darker;
+  border-radius: 7px;
+  padding: 10px;
+  margin: 5px;
+}
+
+.notification-time {
+  font-size: smaller;
+}
+
 /* footer */
 
 footer {

--- a/6_1/ch14/app/channels/application_cable/connection.rb
+++ b/6_1/ch14/app/channels/application_cable/connection.rb
@@ -1,4 +1,19 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+      def find_verified_user
+          @request.session[:init] = true
+          if current_user = User.find_by(id: @request.session[:user_id])
+            current_user
+          else
+            reject_unauthorized_connection
+          end
+      end
   end
 end

--- a/6_1/ch14/app/channels/notifications_channel.rb
+++ b/6_1/ch14/app/channels/notifications_channel.rb
@@ -1,0 +1,9 @@
+class NotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_for current_user
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/6_1/ch14/app/controllers/account_activations_controller.rb
+++ b/6_1/ch14/app/controllers/account_activations_controller.rb
@@ -5,6 +5,11 @@ class AccountActivationsController < ApplicationController
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
       log_in user
+      Notification.create({
+        :user => user,
+        :notification_type => 'first_login',
+        :text => "初回ログインありがとうございます。"
+      })
       flash[:success] = "Account activated!"
       redirect_to user
     else

--- a/6_1/ch14/app/javascript/channels/notifications_channel.js
+++ b/6_1/ch14/app/javascript/channels/notifications_channel.js
@@ -1,0 +1,24 @@
+import consumer from "./consumer"
+
+consumer.subscriptions.create("NotificationsChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // Called when there's incoming data on the websocket for this channel
+    $('#notifications').html('');
+    $.each(data.content, function (index, notification) {
+      $('#notifications').append(
+        '<li><div class="notification">'
+        + '<div class="notification-text">' + notification.text + '</div>'
+        + '<div class="notification-time">' + notification.time + '</div>'
+        + '</div></li>'
+      );
+    });
+  }
+});

--- a/6_1/ch14/app/models/notification.rb
+++ b/6_1/ch14/app/models/notification.rb
@@ -1,0 +1,13 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  validates :user_id, presence: true
+  validates :notification_type, presence: true
+  validates :text, presence: true
+
+  scope :follow, -> { where(notification_type: 'follow') }
+
+  # 更新日時フォーマット
+  def time
+    self.updated_at.strftime('%Y/%m/%d %H:%M')
+  end 
+end

--- a/6_1/ch14/app/models/user.rb
+++ b/6_1/ch14/app/models/user.rb
@@ -90,37 +90,39 @@ class User < ApplicationRecord
 
   # ユーザーをフォローする
   def follow(other_user)
-    following << other_user
+    User.transaction do 
+      following << other_user
 
-    # 通知管理
-    followers_count = other_user.passive_relationships.where('created_at >= ?', 5.minutes.ago).count
-    
-    if followers_count > 1
-      # 5分以内複数のユーザーがフォローした場合、最新の通知更新する
-      text = "#{self.name}さん他#{followers_count - 1}名にフォローされました"
-      other_user.last_follow_notification.update({
-        :text => text
-      })
-    else
-      # 最新の通知から5分ん以上、作成する
-      text = "#{self.name}さんにフォローされました"
-      Notification.create({
-        :user => other_user,
-        :notification_type => 'follow',
-        :text => text
-      })
-    end
-
-    # フォローされたユーザーに通知配信する
-    NotificationsChannel.broadcast_to(
-      other_user,
-      content: other_user.notifications.order({updated_at: :desc}).map do |n|
-        {
-          :text => n.text,
-          :time => n.time
-        }
+      # 通知管理
+      followers_count = other_user.passive_relationships.where('created_at >= ?', 5.minutes.ago).count
+      
+      if followers_count > 1
+        # 5分以内複数のユーザーがフォローした場合、最新の通知更新する
+        text = "#{self.name}さん他#{followers_count - 1}名にフォローされました"
+        other_user.last_follow_notification.update({
+          :text => text
+        })
+      else
+        # 最新の通知から5分ん以上、作成する
+        text = "#{self.name}さんにフォローされました"
+        Notification.create({
+          :user => other_user,
+          :notification_type => 'follow',
+          :text => text
+        })
       end
-    )
+
+      # フォローされたユーザーに通知配信する
+      NotificationsChannel.broadcast_to(
+        other_user,
+        content: other_user.notifications.order({updated_at: :desc}).map do |n|
+          {
+            :text => n.text,
+            :time => n.time
+          }
+        end
+      )
+    end
   end
 
   # ユーザーをフォロー解除する

--- a/6_1/ch14/app/models/user.rb
+++ b/6_1/ch14/app/models/user.rb
@@ -90,39 +90,37 @@ class User < ApplicationRecord
 
   # ユーザーをフォローする
   def follow(other_user)
-    User.transaction do 
-      following << other_user
+    following << other_user
 
-      # 通知管理
-      followers_count = other_user.passive_relationships.where('created_at >= ?', 5.minutes.ago).count
-      
-      if followers_count > 1
-        # 5分以内複数のユーザーがフォローした場合、最新の通知更新する
-        text = "#{self.name}さん他#{followers_count - 1}名にフォローされました"
-        other_user.last_follow_notification.update({
-          :text => text
-        })
-      else
-        # 最新の通知から5分ん以上、作成する
-        text = "#{self.name}さんにフォローされました"
-        Notification.create({
-          :user => other_user,
-          :notification_type => 'follow',
-          :text => text
-        })
-      end
-
-      # フォローされたユーザーに通知配信する
-      NotificationsChannel.broadcast_to(
-        other_user,
-        content: other_user.notifications.order({updated_at: :desc}).map do |n|
-          {
-            :text => n.text,
-            :time => n.time
-          }
-        end
-      )
+    # 通知管理
+    followers_count = other_user.passive_relationships.where('created_at >= ?', 5.minutes.ago).count
+    
+    if followers_count > 1
+      # 5分以内複数のユーザーがフォローした場合、最新の通知更新する
+      text = "#{self.name}さん他#{followers_count - 1}名にフォローされました"
+      other_user.last_follow_notification.update({
+        :text => text
+      })
+    else
+      # 最新の通知から5分ん以上、作成する
+      text = "#{self.name}さんにフォローされました"
+      Notification.create({
+        :user => other_user,
+        :notification_type => 'follow',
+        :text => text
+      })
     end
+
+    # フォローされたユーザーに通知配信する
+    NotificationsChannel.broadcast_to(
+      other_user,
+      content: other_user.notifications.order({updated_at: :desc}).map do |n|
+        {
+          :text => n.text,
+          :time => n.time
+        }
+      end
+    )
   end
 
   # ユーザーをフォロー解除する

--- a/6_1/ch14/app/views/layouts/_header.html.erb
+++ b/6_1/ch14/app/views/layouts/_header.html.erb
@@ -6,6 +6,23 @@
         <li><%= link_to "Home", root_path %></li>
         <li><%= link_to "Help", help_path %></li>
         <% if logged_in? %>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+              Notifications <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu" >
+              <div id="notifications" >
+                <% current_user.notifications.order(updated_at: :desc).each do |notification| %> 
+                  <li>
+                    <div class="notification">
+                      <div class="notification-text"><%= notification.text %></div>
+                      <div class="notification-time"><%= notification.time %></div>
+                    </div>
+                  </li>
+                <% end %>
+              </div>
+            </ul>
+          </li>
           <li><%= link_to "Users", users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/6_1/ch14/db/migrate/20220611144819_create_notifications.rb
+++ b/6_1/ch14/db/migrate/20220611144819_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :notification_type, null: false
+      t.string :text, null: false
+
+      t.timestamps
+    end
+    add_index :notifications, :notification_type
+  end
+end

--- a/6_1/ch14/db/schema.rb
+++ b/6_1/ch14/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_032413) do
+ActiveRecord::Schema.define(version: 2022_06_11_144819) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "notification_type", null: false
+    t.string "text", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notification_type"], name: "index_notifications_on_notification_type"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "followed_id"
@@ -78,4 +88,5 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "microposts", "users"
+  add_foreign_key "notifications", "users"
 end

--- a/6_1/ch14/test/channels/notifications_channel_test.rb
+++ b/6_1/ch14/test/channels/notifications_channel_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class NotificationsChannelTest < ActionCable::Channel::TestCase
+  # test "subscribes" do
+  #   subscribe
+  #   assert subscription.confirmed?
+  # end
+end

--- a/6_1/ch14/test/models/notification_test.rb
+++ b/6_1/ch14/test/models/notification_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  
+  def setup
+    @user = users(:michael)
+    @notification = @user.notifications.build(text: "Lorem ipsum", notification_type: 'type')
+  end
+
+  test "should be valid" do
+    assert @notification.valid?
+  end
+
+  test "user id should be present" do
+    @notification.user_id = nil
+    assert_not @notification.valid?
+  end
+
+  test "text should be present" do
+    @notification.text = nil
+    assert_not @notification.valid?
+  end
+
+  test "notification_type should be present" do
+    @notification.notification_type = nil
+    assert_not @notification.valid?
+  end
+  
+end

--- a/6_1/ch14/test/models/user_test.rb
+++ b/6_1/ch14/test/models/user_test.rb
@@ -89,6 +89,27 @@ class UserTest < ActiveSupport::TestCase
     assert_not michael.following?(archer)
   end
 
+  test "should get follow notifications" do
+    archer   = users(:archer)
+    michael  = users(:michael)
+    lana   = users(:lana)
+    malory   = users(:malory)
+    notification_1 = ['follow', 'Michael Exampleさんにフォローされました']
+    notification_2 = ['follow', 'Lana Kaneさん他1名にフォローされました']
+    notification_3 = ['follow', 'Malory Archerさん他2名にフォローされました']
+    assert_empty archer.followers
+    assert_empty archer.notifications
+    michael.follow(archer)
+    assert_equal archer.notifications.pluck(:notification_type, :text), [notification_1]
+    assert_equal archer.notifications.count, 1
+    lana.follow(archer)
+    assert_equal archer.notifications.pluck(:notification_type, :text), [notification_2]
+    assert_equal archer.notifications.count, 1
+    malory.follow(archer)
+    assert_equal archer.notifications.pluck(:notification_type, :text), [notification_3]
+    assert_equal archer.notifications.count, 1
+  end
+
   test "feed should have the right posts" do
     michael = users(:michael)
     archer  = users(:archer)


### PR DESCRIPTION
### Summary
As requested, a notification system has been added. The notifications are shown to the frontend in realtime through ActionCable.

### Implementation details
Parts that were implemented include:

- Notification model and migration
- notification_channel (ActionCable)
- Header edit (including CSS)
- Tests (Notification and User)

#### Notification model
Creation of the model and its migration. 
The Notification model has a scope for the 'follow' type of notifications, and an attribute to format the updating datetime.
- 'follow' type of Notifications are generated after the relationship is created in the 'follow' method of User.
- 'first_login' kind of notification is generated when the user activates, being the first actual login.

#### ActionCable
The user for the connection is retrieved from the session.
The channel's js replaces the whole notifications dropdown with the notifications it receives. This way even if the logic changes in the future, the dropdown would be updated with just the needed notifications.

#### View edit
Added a scrollable notifications dropdown menu, in the header.
When the ActionCable stream gets updated, the notifications dropdown gets refreshed with all notifications.
The style is not very elaborated, but it should be fine for a start.

#### Tests
Test the notification model and the User 'follow' method, to check notifications are correctly created.

### Possible enhancements

- Testing the cable's connection
- Use an observer to generate notifications
- Notification management (mark read, link to the new relationships, expand the message to show the following users inline, past notifications listing, etc.)  

### 概要
依頼通り、通知システムが追加されました。通知は、ActionCableを通じて、リアルタイムでフロントエンドで見えます。

### 実装詳細
実装された部分は、下記記載を含めています：

- 通知のモデルとマイグレーション
- notification_channel (ActionCable)
- ヘッダー編集　（CSSを含めて）
- テスト（通知とユーザー）

#### 通知のモデル
Notificationというモデルと、それに伴うマイグレーションの作成しました。
Notificationモデルは、フォロータイプの通知のスコープと更新日時をフォーマットするアトリビュートを持っています。
- フォロータイプの通知は、Userのfollowのメソッドで、relationshipが登録された後作成されます。
- 初回ログインタイプの通知は、ユーザーがアクティベートする時に、activation_controllerで作成されます。

#### ActionCable
コネクションのユーザーはセッションから取得されます。
チャンネルのJSは、通知のドロップダウン内容を完全に、チャンネルからもらった通知で入れ替えます。この方法で、ロジックが将来的に変わっても、ドロップダウンは、必要な通知のみで更新されます。

#### ビューの編集
ヘッダーに、スクロールできるドロップダウンメニューを追加しました。
アクションケーブルのストリームが更新される時、通知ドロップダウンが全ての通知で更新されます。
スタイルは特に手は混んではいませんが、まずは足りるかと思います。

#### テスト
通知が正しく作成されるかの確認のため、通知のモデルとUserのfollowのメソッドはテストされます。

### 可能な改善
- ケーブルコネクションのテスト
- 通知の作成をオブサーバーでする
- 通知の管理（読むマークや新しいrelationshipへのリンク、フォローするユーザーをインラインで見せるためメッセージを開く事や過去の通知一覧等）
